### PR TITLE
Change the order services are shutdown.

### DIFF
--- a/src/Sparta-Moz2D/MozServices.class.st
+++ b/src/Sparta-Moz2D/MozServices.class.st
@@ -121,8 +121,8 @@ MozServices class >> stop [
 			isRunning := false.
 			^ self ].
 
-	[	self primShutdownServices.
-		self primShutdownPlatform.
+	[	self primShutdownPlatform.
+		self primShutdownServices.
 		self primStartGfxConfig ]
 	ensure: [ isRunning := false ]
 ]


### PR DESCRIPTION
This avoids the VM crash with the previous version.  I made the changes without any understanding of the Moz2D library, so this should be confirmed by someone with knowledge of the library.