### PR TITLE
Add Skia compositor bindings for filter-below layers

### DIFF
--- a/src/Sparta-Skia/SkiaCompositionFilterBelowLayer.class.st
+++ b/src/Sparta-Skia/SkiaCompositionFilterBelowLayer.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #SkiaCompositionFilterBelowLayer,
+	#superclass : #SkiaCompositionLayer,
+	#category : #'Sparta-Skia-Compositor'
+}
+
+{ #category : #'instance creation' }
+SkiaCompositionFilterBelowLayer class >> filter: aSkiaCompositorFilter geometry: aSkiaCompositorGeometry offset: anOffset [
+	^ self fromNativeHandle: (self
+		primNewFilter: aSkiaCompositorFilter
+		geometry: aSkiaCompositorGeometry
+		offsetX: anOffset x
+		offsetY: anOffset y)
+]
+
+{ #category : #'private - ffi' }
+SkiaCompositionFilterBelowLayer class >> primNewFilter: aSkiaCompositorFilter geometry: aSkiaCompositorGeometry offsetX: anOffsetX offsetY: anOffsetY [
+	^ self ffiCall: #(void* compositor_filter_below_layer_new(
+		SkiaCompositorFilter aSkiaCompositorFilter,
+		SkiaCompositorGeometry aSkiaCompositorGeometry,
+		float32 anOffsetX,
+		float32 anOffsetY))
+]

--- a/src/Sparta-Skia/SkiaCompositorFilter.class.st
+++ b/src/Sparta-Skia/SkiaCompositorFilter.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #SkiaCompositorFilter,
+	#superclass : #SkiaExternalObject,
+	#category : #'Sparta-Skia-Compositor'
+}
+
+{ #category : #'instance creation' }
+SkiaCompositorFilter class >> blur: aNumberOrPoint [
+	| aSigma |
+	aSigma := aNumberOrPoint asPoint.
+	^ self
+		blurSigmaX: aSigma x
+		sigmaY: aSigma y
+]
+
+{ #category : #'instance creation' }
+SkiaCompositorFilter class >> blur: aNumberOrPoint during: aBlock [
+	| aSigma |
+	aSigma := aNumberOrPoint asPoint.
+	^ self
+		blurSigmaX: aSigma x
+		sigmaY: aSigma y
+		during: aBlock
+]
+
+{ #category : #'instance creation' }
+SkiaCompositorFilter class >> blurSigmaX: aSigmaX sigmaY: aSigmaY [
+	^ self fromNativeHandle: (self primBlurSigmaX: aSigmaX sigmaY: aSigmaY)
+]
+
+{ #category : #'instance creation' }
+SkiaCompositorFilter class >> blurSigmaX: aSigmaX sigmaY: aSigmaY during: aBlock [
+	^ self
+		fromNativeHandle: (self primBlurSigmaX: aSigmaX sigmaY: aSigmaY)
+		during: aBlock
+]
+
+{ #category : #'private - ffi' }
+SkiaCompositorFilter class >> primBlurSigmaX: aSigmaX sigmaY: aSigmaY [
+	^ self ffiCall: #(void* compositor_filter_blur_new(float32 aSigmaX, float32 aSigmaY))
+]
+
+{ #category : #'private - ffi' }
+SkiaCompositorFilter class >> primRelease: aHandle [
+	self ffiCall: #(void compositor_filter_drop(void* aHandle))
+]

--- a/src/Sparta-Skia/SkiaCompositorFilterBelowLayerBuilder.class.st
+++ b/src/Sparta-Skia/SkiaCompositorFilterBelowLayerBuilder.class.st
@@ -1,0 +1,71 @@
+Class {
+	#name : #SkiaCompositorFilterBelowLayerBuilder,
+	#superclass : #Object,
+	#instVars : [
+		'filter',
+		'offset'
+	],
+	#category : #'Sparta-Skia-Compositor'
+}
+
+{ #category : #'api - builder' }
+SkiaCompositorFilterBelowLayerBuilder >> buildForGeometry: aSkiaCompositorGeometry [
+	^ SkiaCompositionFilterBelowLayer
+		filter: self filter
+		geometry: aSkiaCompositorGeometry
+		offset: self offset
+]
+
+{ #category : #accessing }
+SkiaCompositorFilterBelowLayerBuilder >> filter [
+	^ filter
+]
+
+{ #category : #accessing }
+SkiaCompositorFilterBelowLayerBuilder >> filter: anObject [
+	filter := anObject
+]
+
+{ #category : #initialization }
+SkiaCompositorFilterBelowLayerBuilder >> initialize [
+	super initialize.
+	offset := 0 @ 0
+]
+
+{ #category : #accessing }
+SkiaCompositorFilterBelowLayerBuilder >> offset [
+	^ offset
+]
+
+{ #category : #accessing }
+SkiaCompositorFilterBelowLayerBuilder >> offset: anObject [
+	offset := anObject
+]
+
+{ #category : #'api - builder' }
+SkiaCompositorFilterBelowLayerBuilder >> pushCircle: aSpartaCircle [
+	^ SkiaCompositorGeometry
+		circle: aSpartaCircle
+		during: [ :aGeometry | self buildForGeometry: aGeometry ]
+]
+
+{ #category : #'api - builder' }
+SkiaCompositorFilterBelowLayerBuilder >> pushPath: aSpartaPath [
+	^ SkiaCompositorGeometry
+		path: aSpartaPath
+		during: [ :aGeometry | self buildForGeometry: aGeometry ]
+]
+
+{ #category : #'api - builder' }
+SkiaCompositorFilterBelowLayerBuilder >> pushRectangle: aSpartaRectangle [
+	^ SkiaCompositorGeometry
+		rectangle: aSpartaRectangle
+		during: [ :aGeometry | self buildForGeometry: aGeometry ]
+]
+
+{ #category : #'api - builder' }
+SkiaCompositorFilterBelowLayerBuilder >> pushRoundedRectangle: aSpartaRoundedRectangle [
+	^ SkiaCompositorGeometry
+		roundedRectangle: aSpartaRoundedRectangle
+		during: [ :aGeometry | self buildForGeometry: aGeometry ]
+]

--- a/src/Sparta-Skia/SkiaFilterPainter.class.st
+++ b/src/Sparta-Skia/SkiaFilterPainter.class.st
@@ -14,6 +14,15 @@ SkiaFilterPainter >> destinationTopLeft [
 			ifNotNil: [ :aRectangle | aRectangle origin ] ]
 ]
 
+{ #category : #accessing }
+SkiaFilterPainter >> sourceToDestinationOffset [
+	<return: #Point>
+
+	^ self destinationTopLeft - (sourceRectangle
+		ifNil: [ 0@0 ]
+		ifNotNil: [ :aRectangle | aRectangle origin ])
+]
+
 { #category : #drawing }
 SkiaFilterPainter >> draw [
 	filter drawOn: self

--- a/src/Sparta-Skia/SkiaSingleSourceFilter.class.st
+++ b/src/Sparta-Skia/SkiaSingleSourceFilter.class.st
@@ -27,7 +27,7 @@ SkiaSingleSourceFilter >> drawOn: aSkiaFilterPainter canvasSource: aSkiaCanvasSo
 				
 				aSkiaFilterPainter canvas surfaceCanvas
 					drawImage: aSkiaImage
-					at: aSkiaFilterPainter destinationTopLeft
+					at: aSkiaFilterPainter sourceToDestinationOffset
 					paint: aSkiaPaint ] ] ]
 ]
 
@@ -40,7 +40,7 @@ SkiaSingleSourceFilter >> drawOn: aSkiaFilterPainter imageSource: aSkiaImageSour
 			
 			aSkiaFilterPainter canvas surfaceCanvas
 				drawImage: aSkiaImageSource image
-				at: aSkiaFilterPainter destinationTopLeft
+				at: aSkiaFilterPainter sourceToDestinationOffset
 				paint: aSkiaPaint ] ]
 ]
 


### PR DESCRIPTION
This change exposes the native compositor filter-below support to Smalltalk so
that Bloc can implement `BlBlurBelowEffect` with the compositor renderer.

Blur below needs a native filter object, geometry describing the affected area,
an offset locating that geometry in the parent surface, and foreground child
layers painted over the filtered pixels. Sparta is the bridge between Bloc's
Smalltalk composition objects and the native objects exported by
`libSkia.dylib`.

This is part of a coordinated group of pull requests across:

- `compositor-rs` (See [https://github.com/feenkcom/compositor-rs/pull/1](https://github.com/feenkcom/compositor-rs/pull/1))
- `libskia`
- `sparta`
- `Bloc`

These changes must be integrated together. This pull request depends on the new
compositor-rs FFI being present in a rebuilt `libSkia.dylib`. The corresponding
Bloc pull request uses the classes introduced here.

## What changed

### Native filter wrapper

Added `SkiaCompositorFilter`, which:

- creates native blur filters from either a number or an X/Y point;
- supports scoped native lifetimes through `during:` variants;
- releases native filter handles through `compositor_filter_drop`.

It calls the following compositor FFI functions:

- `compositor_filter_blur_new`
- `compositor_filter_drop`

### Native filter-below composition layer

Added `SkiaCompositionFilterBelowLayer`, which wraps the native
`FilterBelowLayer` and accepts:

- a `SkiaCompositorFilter`;
- a `SkiaCompositorGeometry`;
- a parent-space offset.

It calls `compositor_filter_below_layer_new` and inherits normal composition
child handling from `SkiaCompositionLayer`.

### Geometry builder

Added `SkiaCompositorFilterBelowLayerBuilder` to convert Sparta geometry into
native compositor geometry. It supports:

- circles;
- paths;
- rectangles;
- rounded rectangles.

The builder follows the same geometry-dispatch pattern already used by other
composition layers such as shadows and clips.

### Static filter source mapping

Added `SkiaFilterPainter>>sourceToDestinationOffset` and changed
`SkiaSingleSourceFilter` to use it when drawing filtered source images.

The required mapping is:

```text
destination origin - source rectangle origin
```

Previously the source image was drawn directly at the destination without
accounting for the source rectangle's position in the source canvas. In scaled
or intermediate preview surfaces this could display pixels from the wrong part
of the enclosing window.
